### PR TITLE
1220 gem testbeam v2

### DIFF
--- a/Geometry/data/testbeam/GEMSpecs.xml
+++ b/Geometry/data/testbeam/GEMSpecs.xml
@@ -27,7 +27,7 @@
     </SpecPar>
     <SpecPar name="dPhiGE11" eval="true">
       <PartSelector path="//GHA1.."/>
-      <Parameter name="dPhi" value="0.00258744*deg"/>
+      <Parameter name="dPhi" value="0.002564*deg"/>
     </SpecPar>
     <SpecPar name="dPhiGE21" eval="true">
       <PartSelector path="//GHA2.."/>

--- a/Geometry/data/testbeam/gem11.xml
+++ b/Geometry/data/testbeam/gem11.xml
@@ -11,7 +11,7 @@
 
 <ConstantsSection label="gem11.xml" eval="true">
   <!-- ETA PARTITIONS -->
-  <Constant name="tkgem" value="4.9750*cm"/> <!-- eta partition heights -->
+  <Constant name="tkgem" value="4.4750*cm"/> <!-- eta partition heights -->
   <Constant name="dzS1L" value="[tkgem]"/> <!-- eta partition heights -->
   <Constant name="dzS2L" value="[tkgem]"/>
   <Constant name="dzS3L" value="[tkgem]"/>
@@ -321,10 +321,10 @@
   <Trd1 name="GGA116" dz="[dzS6S]" dy1="[dyGap2]" dy2="[dyGap2]" dx1="[dx61S]" dx2="[dx62S]" />
   <Trd1 name="GGA117" dz="[dzS7S]" dy1="[dyGap2]" dy2="[dyGap2]" dx1="[dx71S]" dx2="[dx72S]" />
   <Trd1 name="GGA118" dz="[dzS8S]" dy1="[dyGap2]" dy2="[dyGap2]" dx1="[dx81S]" dx2="[dx82S]" />
-  <Trd1 name="GHA101" dz="4.45*cm" dy1="[dyGap1]" dy2="[dyGap1]" dx1="4.4499*cm" dx2="4.4501*cm" />
-  <Trd1 name="GHA102" dz="4.45*cm" dy1="[dyGap1]" dy2="[dyGap1]" dx1="4.4499*cm" dx2="4.4501*cm" />
-  <Trd1 name="GHA103" dz="4.45*cm" dy1="[dyGap1]" dy2="[dyGap1]" dx1="4.4499*cm" dx2="4.4501*cm" />
-  <Trd1 name="GHA104" dz="4.45*cm" dy1="[dyGap1]" dy2="[dyGap1]" dx1="4.4499*cm" dx2="4.4501*cm" />
+  <Trd1 name="GHA101" dz="4.475*cm" dy1="[dyGap1]" dy2="[dyGap1]" dx1="4.47499*cm" dx2="4.47501*cm" />
+  <Trd1 name="GHA102" dz="4.475*cm" dy1="[dyGap1]" dy2="[dyGap1]" dx1="4.47499*cm" dx2="4.47501*cm" />
+  <Trd1 name="GHA103" dz="4.475*cm" dy1="[dyGap1]" dy2="[dyGap1]" dx1="4.47499*cm" dx2="4.47501*cm" />
+  <Trd1 name="GHA104" dz="4.475*cm" dy1="[dyGap1]" dy2="[dyGap1]" dx1="4.47499*cm" dx2="4.47501*cm" />
   <!-- <Trd1 name="GHA101" dz="[dzS1L]" dy1="[dyGap1]" dy2="[dyGap1]" dx1="[dx11L]" dx2="[dx12L]" />
   <Trd1 name="GHA102" dz="[dzS2L]" dy1="[dyGap1]" dy2="[dyGap1]" dx1="[dx21L]" dx2="[dx22L]" />
   <Trd1 name="GHA103" dz="[dzS3L]" dy1="[dyGap1]" dy2="[dyGap1]" dx1="[dx31L]" dx2="[dx32L]" />


### PR DESCRIPTION
update GEM Tracker geometry: 8.95cm width and height
procedure for calculating dPhi in GEMSpecs.xml:
dPhi = arctan(h/(B-b))
where 
h = height = 4.475
b = lower width = 4.47499
B = higher width = 4.47501
thereafter few iterations
from dPhi = 0.002561
to dPhi = 0.002564
to reach pitch 0.249983 